### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,16 @@ WORKDIR /usr/src/app
 # where available (npm@5+)
 COPY package*.json ./
 
+RUN apk --no-cache add --virtual native-deps g++ gcc libgcc libstdc++ linux-headers make python3
+RUN npm install node-gyp -g
 RUN npm install
+RUN apk del native-deps
+
+# RUN npm install
 # If you are building your code for production
 # RUN npm ci --only=production
 
 # Bundle app source
-COPY . .
+COPY index.js .
 
-CMD [ "node", "index.js" ]
+CMD [ "npm", "start" ]


### PR DESCRIPTION
The docker build failed, because the build tools are not available in `node:alpine`. The updated script installs the build tools, runs npm install and then removes the build tools to free space.

Also, the CMD is updated to `npm start` instead of `node index.js`. This way, the start command is managed by the `package.json`.